### PR TITLE
columns of grid table are not translated

### DIFF
--- a/x2engine/protected/models/X2Model.php
+++ b/x2engine/protected/models/X2Model.php
@@ -131,7 +131,7 @@ abstract class X2Model extends CActiveRecord {
 		// don't call attributeLabels(), just look in self::$_fields
 		foreach(self::$_fields as &$_field) {
 			if($_field->fieldName == $attribute)
-				return $_field->attributeLabel;
+				return Yii::t(strtolower(get_class($this)),$_field->attributeLabel);
 		}
 		// original Yii code
 		if(strpos($attribute,'.')!==false) {


### PR DESCRIPTION
columns of grid table (contacts, sales, etc. for example) are not translated in the right language (i'm using italian).
This patch should fix the problem.

Please be patient, i'm a newbie of github :-)
